### PR TITLE
Add workaround for pyright workspace folder initialisation

### DIFF
--- a/src/main/kotlin/com/insyncwithfoo/pyrightexperimental/PyrightLspServerDescriptor.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightexperimental/PyrightLspServerDescriptor.kt
@@ -3,6 +3,7 @@ package com.insyncwithfoo.pyrightexperimental
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.LspServerListener
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import java.io.File
 
@@ -15,6 +16,8 @@ class PyrightLspServerDescriptor(
     override fun isSupportedFile(file: VirtualFile) = file.extension == "py"
 
     override fun createCommandLine() = GeneralCommandLine(executable.absolutePath, "--stdio")
+
+    override val lspServerListener = PyrightLspServerListener(project)
 
     companion object {
         const val PRESENTABLE_NAME = "Pyright"

--- a/src/main/kotlin/com/insyncwithfoo/pyrightexperimental/PyrightLspServerListener.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightexperimental/PyrightLspServerListener.kt
@@ -1,0 +1,20 @@
+package com.insyncwithfoo.pyrightexperimental
+
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.LspServerListener
+import com.intellij.platform.lsp.api.LspServerManager
+import org.eclipse.lsp4j.DidChangeConfigurationParams
+import org.eclipse.lsp4j.InitializeResult
+
+@Suppress("UnstableApiUsage")
+class PyrightLspServerListener(val project: Project) : LspServerListener {
+    override fun serverInitialized(params: InitializeResult) {
+        // pyright waits for all workspace folders to be initialised before processing
+        // codeAction requests, but it never actually finishes initialising the workspace folders
+        // sent with the initialize request unless kickstarted with an (empty) didChangeConfiguration notification
+        // see: https://github.com/microsoft/pyright/issues/6874
+        LspServerManager.getInstance(project).getServersForProvider(PyrightLspServerSupportProvider::class.java).forEach {
+            it.lsp4jServer.workspaceService.didChangeConfiguration(DidChangeConfigurationParams())
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple workaround for ensuring that Pyright properly initialises the workspace folders sent in the `initialize` request, see the comment in the code as well as https://github.com/microsoft/pyright/issues/6874 for more details.

This seems to be enough to get Pyright sending responses:

![image](https://github.com/InSyncWithFoo/pyright-experimental-plugin/assets/885076/de0be514-da26-42e8-816d-56bb535fda9f)
