### PR TITLE
Allow using source roots as `workspaceFolders`

### DIFF
--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/AllConfigurations.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/AllConfigurations.kt
@@ -1,6 +1,7 @@
 package com.insyncwithfoo.pyrightls.configuration
 
 import com.insyncwithfoo.pyrightls.configuration.application.LogLevel
+import com.insyncwithfoo.pyrightls.configuration.project.WorkspaceFolders
 import org.jetbrains.annotations.SystemDependent
 import com.insyncwithfoo.pyrightls.configuration.application.Configurations as ApplicationConfigurations
 import com.insyncwithfoo.pyrightls.configuration.project.Configurations as ProjectConfigurations
@@ -19,7 +20,8 @@ internal infix fun ApplicationConfigurations.mergeWith(other: ProjectConfigurati
         logLevel = this.logLevel,
         
         projectExecutable = other.projectExecutable,
-        autoSuggestExecutable = other.autoSuggestExecutable
+        autoSuggestExecutable = other.autoSuggestExecutable,
+        workspaceFolders = other.workspaceFolders
     )
 
 
@@ -35,7 +37,8 @@ internal data class AllConfigurations(
     val logLevel: LogLevel,
     
     val projectExecutable: @SystemDependent String?,
-    val autoSuggestExecutable: Boolean
+    val autoSuggestExecutable: Boolean,
+    val workspaceFolders: WorkspaceFolders
 ) {
     val executable: @SystemDependent String?
         get() = when {

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/ConfigurationPanel.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/ConfigurationPanel.kt
@@ -10,12 +10,16 @@ import com.insyncwithfoo.pyrightls.configuration.secondColumnPathInput
 import com.insyncwithfoo.pyrightls.message
 import com.insyncwithfoo.pyrightls.path
 import com.insyncwithfoo.pyrightls.resolvedAgainst
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Row
+import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
 
 
 private fun unresolvablePathHint() =
@@ -28,6 +32,15 @@ private fun Row.makeProjectExecutableInput(block: Cell<TextFieldWithBrowseButton
 
 private fun Row.makeAutoSuggestExecutableInput(block: Cell<JBCheckBox>.() -> Unit) =
     checkBox(message("configurations.project.autoSuggestExecutable.label")).apply(block)
+
+
+private fun Row.makeWorkspaceFoldersInput(block: Cell<ComboBox<WorkspaceFolders>>.() -> Unit) = run {
+    val renderer = SimpleListCellRenderer.create<WorkspaceFolders> { label, value, _ ->
+        label.text = value.label
+    }
+    
+    comboBox(WorkspaceFolders.entries, renderer).apply(block)
+}
 
 
 internal fun Configurable.configurationPanel(state: Configurations) = panel {
@@ -48,6 +61,13 @@ internal fun Configurable.configurationPanel(state: Configurations) = panel {
             
             prefilledWithRandomPlaceholder()
             bindText(state::projectExecutable)
+        }
+    }
+    
+    @Suppress("DialogTitleCapitalization")
+    group(message("configurations.global.group.languageServer")) {
+        row(message("configurations.project.workspaceFolders.label")) {
+            makeWorkspaceFoldersInput { bindItem(state::workspaceFolders.toNullableProperty()) }
         }
     }
     

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/Configurations.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/Configurations.kt
@@ -5,8 +5,8 @@ import com.intellij.openapi.components.BaseState
 
 
 internal enum class WorkspaceFolders(val label: String) {
-    PROJECT_BASE(message("configurations.project.workspaceFolders.default.label")),
-    SOURCE_ROOTS(message("configurations.project.workspaceFolders.sourceRoots.label"));
+    PROJECT_BASE(message("configurations.project.workspaceFolders.projectBase")),
+    SOURCE_ROOTS(message("configurations.project.workspaceFolders.sourceRoots"));
 }
 
 

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/Configurations.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/project/Configurations.kt
@@ -1,9 +1,18 @@
 package com.insyncwithfoo.pyrightls.configuration.project
 
+import com.insyncwithfoo.pyrightls.message
 import com.intellij.openapi.components.BaseState
+
+
+internal enum class WorkspaceFolders(val label: String) {
+    PROJECT_BASE(message("configurations.project.workspaceFolders.default.label")),
+    SOURCE_ROOTS(message("configurations.project.workspaceFolders.sourceRoots.label"));
+}
 
 
 internal class Configurations : BaseState() {
     var projectExecutable by string(null)
     var autoSuggestExecutable by property(true)
+    
+    var workspaceFolders by enum(WorkspaceFolders.PROJECT_BASE)
 }

--- a/src/main/resources/messages/pyrightls.properties
+++ b/src/main/resources/messages/pyrightls.properties
@@ -21,6 +21,10 @@ configurations.project.displayName = Pyright LS (Project)
 configurations.project.projectExecutable.label = Project executable:
 configurations.project.autoSuggestExecutable.label = Suggest executable on project open
 
+configurations.project.workspaceFolders.label = Workspace folders:
+configurations.project.workspaceFolders.default.label = Project base directories
+configurations.project.workspaceFolders.sourceRoots.label = Source roots
+
 configurations.hint.fileFound = File found
 configurations.hint.fileNotExecutable = File is not executable
 configurations.hint.fileNotFound = No file found at given path

--- a/src/main/resources/messages/pyrightls.properties
+++ b/src/main/resources/messages/pyrightls.properties
@@ -20,10 +20,9 @@ configurations.global.logLevel.trace = Trace
 configurations.project.displayName = Pyright LS (Project)
 configurations.project.projectExecutable.label = Project executable:
 configurations.project.autoSuggestExecutable.label = Suggest executable on project open
-
 configurations.project.workspaceFolders.label = Workspace folders:
-configurations.project.workspaceFolders.default.label = Project base directories
-configurations.project.workspaceFolders.sourceRoots.label = Source roots
+configurations.project.workspaceFolders.projectBase = Project base directories
+configurations.project.workspaceFolders.sourceRoots = Source roots
 
 configurations.hint.fileFound = File found
 configurations.hint.fileNotExecutable = File is not executable

--- a/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
+++ b/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
@@ -1,6 +1,7 @@
 package com.insyncwithfoo.pyrightls.configuration
 
 import com.insyncwithfoo.pyrightls.configuration.application.LogLevel
+import com.insyncwithfoo.pyrightls.configuration.project.WorkspaceFolders
 import junit.framework.TestCase
 import com.insyncwithfoo.pyrightls.configuration.application.Configurations as ApplicationConfigurations
 import com.insyncwithfoo.pyrightls.configuration.project.Configurations as ProjectConfigurations
@@ -42,11 +43,13 @@ class ConfigurationFieldsTest : TestCase() {
     fun `test defaults - project`() {
         val configurations = ProjectConfigurations()
         
-        assertEquals(2, projectFields().size)
+        assertEquals(3, projectFields().size)
         
         configurations.run {
             assertEquals(null, projectExecutable)
             assertEquals(true, autoSuggestExecutable)
+            
+            assertEquals(WorkspaceFolders.PROJECT_BASE, workspaceFolders)
         }
     }
     

--- a/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
+++ b/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
@@ -48,6 +48,7 @@ class ConfigurationFieldsTest : TestCase() {
         configurations.run {
             assertEquals(null, projectExecutable)
             assertEquals(true, autoSuggestExecutable)
+            
             assertEquals(WorkspaceFolders.PROJECT_BASE, workspaceFolders)
         }
     }

--- a/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
+++ b/src/test/kotlin/com/insyncwithfoo/pyrightls/configuration/ConfigurationFieldsTest.kt
@@ -48,7 +48,6 @@ class ConfigurationFieldsTest : TestCase() {
         configurations.run {
             assertEquals(null, projectExecutable)
             assertEquals(true, autoSuggestExecutable)
-            
             assertEquals(WorkspaceFolders.PROJECT_BASE, workspaceFolders)
         }
     }


### PR DESCRIPTION
Fix #18.