### PR TITLE
Allow suppressing diagnostics via quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For code changes, see [`CHANGELOG_CODE.md`][_-1].
 
 ## [Unreleased]
 
+### Added
+
+* Diagnostics can now be suppressed using quick fixes.
+
 ### Changed
 
 * An informational hint will now be given if

--- a/CHANGELOG_CODE.md
+++ b/CHANGELOG_CODE.md
@@ -16,26 +16,29 @@ For user-facing changes, see [`CHANGELOG.md`][_-1].
 
 * [`PyrightLSDescriptor`][40-1] now logs all configurations on initialization.
   (501b9cea)
+* Diagnostics-related construct, including those newly added for quick fixes,
+  are moved to the [`.diagnostics`][40-2] module. (HEAD)
 
 ### Changed
 
-* [The Qodana Gradle plugin][40-2] and its corresponding action
-  [@JetBrains/qodana-action][40-3] are updated to 2024.1.4.
+* [The Qodana Gradle plugin][40-3] and its corresponding action
+  [@JetBrains/qodana-action][40-4] are updated to 2024.1.4.
   (647bd2d5, 26a9fcf9, b952ef10, 1ae17a00, bed1cfe6, 6bd68dfd)
-* A new branch is added to [`executablePathResolvingHint()`][40-4]. (906f7abe)
-* [Kotlin JVM plugin][40-5] is updated to 1.9.24. (0e28e9ae)
-* `RoamingType.LOCAL` is used for [application-level configurations][40-6]
+* A new branch is added to [`executablePathResolvingHint()`][40-5]. (906f7abe)
+* [Kotlin JVM plugin][40-6] is updated to 1.9.24. (0e28e9ae)
+* `RoamingType.LOCAL` is used for [application-level configurations][40-7]
   instead of `RoamingType.DISABLED`. (ac6bf02a)
 * The "Run Plugin" task now runs with the new UI enabled and
   the `.idea` subdirectory not hidden. (5fb15568)
 
 
   [40-1]: https://github.com/InSyncWithFoo/pyright-langserver-for-pycharm/blob/501b9cea/src/main/kotlin/com/insyncwithfoo/pyrightls/server/PyrightLSDescriptor.kt
-  [40-2]: https://plugins.gradle.org/plugin/org.jetbrains.qodana
-  [40-3]: https://github.com/JetBrains/qodana-action
-  [40-4]: https://github.com/InSyncWithFoo/pyright-for-pycharm/blob/906f7abe/src/main/kotlin/com/insyncwithfoo/pyright/configuration/PathResolvingHint.kt
-  [40-5]: https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
-  [40-6]: https://github.com/InSyncWithFoo/pyright-langserver-for-pycharm/blob/ac6bf02a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/ConfigurationService.kt
+  [40-2]: https://github.com/InSyncWithFoo/pyright-langserver-for-pycharm/blob/HEAD/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics
+  [40-3]: https://plugins.gradle.org/plugin/org.jetbrains.qodana
+  [40-4]: https://github.com/JetBrains/qodana-action
+  [40-5]: https://github.com/InSyncWithFoo/pyright-for-pycharm/blob/906f7abe/src/main/kotlin/com/insyncwithfoo/pyright/configuration/PathResolvingHint.kt
+  [40-6]: https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
+  [40-7]: https://github.com/InSyncWithFoo/pyright-langserver-for-pycharm/blob/ac6bf02a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/ConfigurationService.kt
 
 
 ## [0.3.0] - 2024-04-24

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/PyrightLSDescriptor.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/PyrightLSDescriptor.kt
@@ -4,6 +4,7 @@ import com.insyncwithfoo.pyrightls.configuration.project.WorkspaceFolders
 import com.insyncwithfoo.pyrightls.message
 import com.insyncwithfoo.pyrightls.path
 import com.insyncwithfoo.pyrightls.pyrightLSConfigurations
+import com.insyncwithfoo.pyrightls.server.diagnostics.DiagnosticsSupport
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/PyrightIgnoreComment.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/PyrightIgnoreComment.kt
@@ -1,0 +1,97 @@
+package com.insyncwithfoo.pyrightls.server.diagnostics
+
+
+// From https://github.com/microsoft/pyright/blob/496e50f6/packages/pyright-internal/src/parser/tokenizer.ts#L1302
+private val pyrightIgnoreSyntax = """(?x)
+    (?<prefix>\#\s*pyright:\s*ignore)
+    (?:
+        (?<padding>\s*)
+        (?<codeList>\[[\s*\w-,]*])
+    )?
+""".toRegex()
+
+
+private fun MatchGroup.toFragment(baseOffset: Int): PyrightIgnoreCommentFragment {
+    val selfRelativeOffset = range.first
+    return PyrightIgnoreCommentFragment(value, baseOffset + selfRelativeOffset)
+}
+
+
+private fun String.stripBrackets() = this.substring(1, length - 1)
+
+
+internal class PyrightIgnoreCommentFragment(val content: String, baseOffset: Int) {
+    val start = baseOffset
+    val end = baseOffset + content.length
+}
+
+
+internal class PyrightIgnoreComment(val codes: Set<PyrightErrorCode>) {
+    
+    val codeList: String
+        get() = "[${codes.joinToString(", ")}]"
+    
+    override fun toString(): String {
+        val affix = when {
+            codes.isEmpty() -> ""
+            else -> " $codeList"
+        }
+        return "# pyright: ignore${affix}"
+    }
+    
+    companion object {
+        
+        fun parse(codeList: String): PyrightIgnoreComment {
+            val codes = codeList.split(",").mapNotNullTo(mutableSetOf()) { code ->
+                code.trim().takeIf { it.isNotEmpty() }
+            }
+            
+            return PyrightIgnoreComment(codes)
+        }
+        
+        fun parse(fragment: PyrightIgnoreCommentFragment): PyrightIgnoreComment {
+            return parse(fragment.content.stripBrackets())
+        }
+        
+    }
+    
+}
+
+
+internal class ExistingPyrightIgnoreComment(
+    private val prefix: PyrightIgnoreCommentFragment,
+    private val padding: PyrightIgnoreCommentFragment?,
+    private val codeList: PyrightIgnoreCommentFragment?
+) {
+    
+    val codes by lazy { codeList?.let { PyrightIgnoreComment.parse(it).codes } ?: emptySet() }
+    
+    val codeListIsNotSpecified: Boolean
+        get() = codeList == null
+    
+    val codeListRemovalOffsets: Pair<Int, Int>
+        get() = when {
+            codeList != null -> padding!!.start to codeList.end
+            else -> prefix.end to prefix.end
+        }
+    
+    val codeListReplacementOffsets: Pair<Int, Int>
+        get() = when {
+            codeList != null -> codeList.start to codeList.end
+            else -> prefix.end to prefix.end
+        }
+    
+    companion object {
+        fun create(text: String, baseOffset: Int): ExistingPyrightIgnoreComment? {
+            val pyrightIgnorePart = pyrightIgnoreSyntax.find(text) ?: return null
+            val groups = pyrightIgnorePart.groups
+            
+            val prefix = groups["prefix"]!!.toFragment(baseOffset)
+            val padding = groups["padding"]?.toFragment(baseOffset)
+            val codeList = groups["codeList"]?.toFragment(baseOffset)
+            
+            return ExistingPyrightIgnoreComment(prefix, padding, codeList)
+        }
+    }
+    
+}

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/QuickFix.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/QuickFix.kt
@@ -76,8 +76,10 @@ class SuppressQuickFix(
     
     override fun getText() = "Suppress ${code ?: "this Pyright diagnostic"}"
     
-    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?) =
-        editor != null && editor.caretModel.offset in range
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        val offset = editor?.caretModel?.offset ?: return false
+        return range.startOffset <= offset && offset <= range.endOffset
+    }
     
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         if (editor == null || file == null) {

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/QuickFix.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/QuickFix.kt
@@ -1,0 +1,98 @@
+package com.insyncwithfoo.pyrightls.server.diagnostics
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiFile
+import com.jetbrains.python.psi.PyUtil
+import com.jetbrains.python.psi.impl.PyPsiUtils
+
+
+internal typealias PyrightErrorCode = String
+
+
+private fun Document.appendToLine(line: Int, value: String) {
+    val lineEndOffset = getLineEndOffset(line)
+    replaceString(lineEndOffset, lineEndOffset, value)
+}
+
+
+private fun PsiFile.findSameLineComment(rangeOffset: Int): PsiComment? {
+    return findElementAt(rangeOffset)?.let { PyPsiUtils.findSameLineComment(it) }
+}
+
+
+private fun PsiFile.edit(callback: (Document) -> Unit) {
+    PyUtil.updateDocumentUnblockedAndCommitted(this, callback)
+}
+
+
+class SuppressQuickFix(
+    private val code: PyrightErrorCode?,
+    private val range: TextRange
+) : IntentionAction {
+    
+    private fun Document.appendNewCommentToLine() {
+        val lineNumber = getLineNumber(range.startOffset)
+        val lastCharacter = charsSequence[getLineEndOffset(lineNumber) - 1]
+        
+        val padding = when {
+            lastCharacter == ' ' -> ""
+            else -> "  "
+        }
+        
+        appendToLine(lineNumber, padding + PyrightIgnoreComment.parse(code ?: ""))
+    }
+    
+    private fun Document.removeCommentCodeList(comment: ExistingPyrightIgnoreComment) {
+        val (start, end) = comment.codeListRemovalOffsets
+        replaceString(start, end, "")
+    }
+    
+    private fun Document.addNewCodeToExistingComment(comment: ExistingPyrightIgnoreComment) {
+        val (start, end) = comment.codeListReplacementOffsets
+        replaceString(start, end, comment.replacement)
+    }
+    
+    private val ExistingPyrightIgnoreComment.replacement: String
+        get() {
+            val newCodes = codes + code!!
+            val newComment = PyrightIgnoreComment(newCodes)
+            
+            val padding = when {
+                codeListIsNotSpecified -> " "
+                else -> ""
+            }
+            
+            return padding + newComment.codeList
+        }
+    
+    override fun startInWriteAction() = true
+    
+    override fun getFamilyName() = "Suppress Pyright diagnostics"
+    
+    override fun getText() = "Suppress ${code ?: "this Pyright diagnostic"}"
+    
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?) =
+        editor != null && editor.caretModel.offset in range
+    
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        if (editor == null || file == null) {
+            return
+        }
+        
+        val existingComment = file.findSameLineComment(range.startOffset)
+            ?.let { ExistingPyrightIgnoreComment.create(it.text, it.textOffset) }
+        
+        when {
+            existingComment == null -> file.edit { it.appendNewCommentToLine() }
+            code == null -> file.edit { it.removeCommentCodeList(existingComment) }
+            else -> file.edit { it.addNewCodeToExistingComment(existingComment) }
+        }
+        
+    }
+    
+}

--- a/src/test/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/TestExistingPyrightIgnoreComment.kt
+++ b/src/test/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/TestExistingPyrightIgnoreComment.kt
@@ -1,0 +1,206 @@
+package com.insyncwithfoo.pyrightls.server.diagnostics
+
+import junit.framework.TestCase
+
+
+private fun String.firstPyrightIgnoreEndIndex(): Int {
+    return """#\s*pyright:\s*ignore""".toRegex().find(this)!!.range.last + 1
+}
+
+
+private fun String.firstPyrightIgnoreEndIndexPair(): Pair<Int, Int> {
+    val endIndex = firstPyrightIgnoreEndIndex()
+    return endIndex to endIndex
+}
+
+
+private fun String.firstSquareBracketPairIndices(): Pair<Int, Int> {
+    val opening = indexOf('[')
+    val closing = indexOf(']', opening)
+    
+    return opening to closing + 1
+}
+
+
+private fun String.firstPyrightIgnoreEndToNextClosingBracketIndices(): Pair<Int, Int> {
+    val pyrightIgnoreEnd = firstPyrightIgnoreEndIndex()
+    val closingBracket = indexOf(']', pyrightIgnoreEnd)
+    
+    return pyrightIgnoreEnd to closingBracket + 1
+}
+
+
+class TestExistingPyrightIgnoreComment : TestCase() {
+    
+    fun `test create - no codes`() {
+        val input = "# pyright: ignore"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(emptySet<String>(), parsed.codes)
+        assertEquals(true, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - empty list`() {
+        val input = "# pyright: ignore []"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(emptySet<String>(), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - one code`() {
+        val input = "# pyright: ignore [A]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple codes`() {
+        val input = "# pyright: ignore [A, B]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple duplicate codes`() {
+        val input = "# pyright: ignore [A, A, B, , ,D, , C, D, ]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B", "D", "C"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - whitespace`() {
+        val input = "#     pyright:\t\tignore[A,   ,\t,\t\t,,B,\t,  , D, C ,, E E,,,F]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B", "D", "C", "E E", "F"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - no codes`() {
+        val input = "# foo # pyright: ignore"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(emptySet<String>(), parsed.codes)
+        assertEquals(true, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - empty list`() {
+        val input = "# foo # pyright: ignore []"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(emptySet<String>(), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - one code`() {
+        val input = "# foo # pyright: ignore [A]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple codes`() {
+        val input = "# foo # pyright: ignore [A, B]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple duplicate codes`() {
+        val input = "# foo # pyright: ignore [A, A, B, , ,D, , C, D, ]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B", "D", "C"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple valid parts - no codes`() {
+        val input = "# foo # pyright: ignore  # pyright: ignore []"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(emptySet<String>(), parsed.codes)
+        assertEquals(true, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndIndexPair(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple valid parts - one code`() {
+        val input = "# foo # pyright: ignore [A]  # pyright: ignore []"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple valid parts - multiple codes`() {
+        val input = "# foo # pyright: ignore[A, B]  # pyright: ignore [C, D]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - multiple hashes - multiple valid parts - multiple duplicate codes`() {
+        val input = "# foo # pyright: ignore [A, A, B, , ,D, , C, D, ]  # pyright: ignore [A]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)!!
+        
+        assertEquals(setOf("A", "B", "D", "C"), parsed.codes)
+        assertEquals(false, parsed.codeListIsNotSpecified)
+        assertEquals(input.firstSquareBracketPairIndices(), parsed.codeListReplacementOffsets)
+        assertEquals(input.firstPyrightIgnoreEndToNextClosingBracketIndices(), parsed.codeListRemovalOffsets)
+    }
+    
+    fun `test create - invalid - type ignore`() {
+        val input = "# type: ignore [A, B]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)
+        
+        assertEquals(null, parsed)
+    }
+    
+    fun `test create - invalid - marker not immediately preceded by hash`() {
+        val input = "# foo pyright: ignore [A, B]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)
+        
+        assertEquals(null, parsed)
+    }
+    
+    fun `test create - invalid - whitespace before colon`() {
+        val input = "# pyright : ignore [A, B]"
+        val parsed = ExistingPyrightIgnoreComment.create(input, 0)
+        
+        assertEquals(null, parsed)
+    }
+    
+}

--- a/src/test/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/TestPyrightIgnoreComment.kt
+++ b/src/test/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/TestPyrightIgnoreComment.kt
@@ -1,0 +1,53 @@
+package com.insyncwithfoo.pyrightls.server.diagnostics
+
+import junit.framework.TestCase
+
+
+class TestPyrightIgnoreComment : TestCase() {
+    
+    fun `test parse - empty`() {
+        val input = ""
+        val comment = PyrightIgnoreComment.parse(input)
+        
+        assertEquals(emptySet<PyrightErrorCode>(), comment.codes)
+        assertEquals("[]", comment.codeList)
+        assertEquals("# pyright: ignore", comment.toString())
+    }
+    
+    fun `test parse - one code`() {
+        val input = "A"
+        val comment = PyrightIgnoreComment.parse(input)
+        
+        assertEquals(setOf("A"), comment.codes)
+        assertEquals("[A]", comment.codeList)
+        assertEquals("# pyright: ignore [A]", comment.toString())
+    }
+    
+    fun `test parse - multiple codes`() {
+        val input = "A, B, C"
+        val comment = PyrightIgnoreComment.parse(input)
+        
+        assertEquals(setOf("A", "B", "C"), comment.codes)
+        assertEquals("[A, B, C]", comment.codeList)
+        assertEquals("# pyright: ignore [A, B, C]", comment.toString())
+    }
+    
+    fun `test parse - multiple duplicate codes`() {
+        val input = "A, A, B, , ,D, , C, D, "
+        val comment = PyrightIgnoreComment.parse(input)
+        
+        assertEquals(setOf("A", "B", "D", "C"), comment.codes)
+        assertEquals("[A, B, D, C]", comment.codeList)
+        assertEquals("# pyright: ignore [A, B, D, C]", comment.toString())
+    }
+    
+    fun `test parse - whitespace`() {
+        val input = "   A ,B, C   "
+        val comment = PyrightIgnoreComment.parse(input)
+        
+        assertEquals(setOf("A", "B", "C"), comment.codes)
+        assertEquals("[A, B, C]", comment.codeList)
+        assertEquals("# pyright: ignore [A, B, C]", comment.toString())
+    }
+    
+}


### PR DESCRIPTION
Presumably fixes #40. Not entirely tested, but relatively good-looking. Will merge as soon as I'm able to confirm that it works on PyCharm.