### PR TITLE
Add Pretty Format Option for Tooltip

### DIFF
--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/AllConfigurations.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/AllConfigurations.kt
@@ -31,6 +31,7 @@ internal infix fun ApplicationConfigurations.mergeWith(other: ProjectConfigurati
         monkeypatchAutoImportDetails = this.monkeypatchAutoImportDetails,
         monkeypatchTrailingQuoteBug = this.monkeypatchTrailingQuoteBug,
         locale = this.locale,
+        prettyOutput = this.prettyOutput,
         
         projectExecutable = other.projectExecutable,
         autoSuggestExecutable = other.autoSuggestExecutable,
@@ -59,6 +60,7 @@ internal data class AllConfigurations(
     val monkeypatchAutoImportDetails: Boolean,
     val monkeypatchTrailingQuoteBug: Boolean,
     val locale: Locale,
+    val prettyOutput: Boolean,
     
     val projectExecutable: @SystemDependent String?,
     val autoSuggestExecutable: Boolean,

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/ConfigurationPanel.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/ConfigurationPanel.kt
@@ -34,6 +34,9 @@ private fun Row.makeGlobalExecutableInput(block: Cell<TextFieldWithBrowseButton>
     textFieldWithBrowseButton().makeFlexible().apply(block)
 
 
+private fun Row.makePrettyOutputInput(block: Cell<JBCheckBox>.() -> Unit) =
+    checkBox(message("configurations.prettyOutput.label")).apply(block)
+
 private fun Row.makeUseEditorFontInput(block: Cell<JBCheckBox>.() -> Unit) =
     checkBox(message("configurations.useEditorFont.label")).apply(block)
 
@@ -142,6 +145,9 @@ internal fun configurationPanel(state: Configurations) = panel {
         }
         row {
             makeLinkErrorCodesInput { bindSelected(state::linkErrorCodes) }
+        }
+        row {
+            makePrettyOutputInput { bindSelected(state::prettyOutput)}
         }
         row(message("configurations.locale.label")) {
             makeLocaleInput { bindItem(state::locale.toNullableProperty()) }

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/Configurations.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/configuration/application/Configurations.kt
@@ -52,4 +52,5 @@ internal class Configurations : BaseState() {
     var monkeypatchAutoImportDetails by property(true)
     var monkeypatchTrailingQuoteBug by property(true)
     var locale by enum(Locale.DEFAULT)
+    var prettyOutput by property(true)
 }

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
@@ -28,13 +28,21 @@ private fun HtmlChunk.Element.withFont(font: String?) =
     this.runIf(font != null) { style("font-family: '$font'") }
 
 
-private fun String.toPreformattedBlock(font: String?) =
-    HtmlChunk.div().withFont(font).child(HtmlChunk.text(this))
+private val QUOTED_TEXT_REGEX = "\"([^\"]+)\"".toRegex()
+
+
+private fun String.replaceQuotesWithCode(): String =
+    QUOTED_TEXT_REGEX.replace(this) { "<code>${it.groupValues[1]}</code>" }
+
+
+private fun String.toPreformattedBlock(font: String?): HtmlChunk.Element {
+    return HtmlChunk.div().withFont(font).child(HtmlChunk.raw(replaceQuotesWithCode()))
+}
 
 
 private fun String.toCodeSuffix(font: String? = null, href: String? = null): String {
     val parenthesizedPortion = href?.let { HtmlChunk.link(it, this).withFont(font) } ?: this
-    return " ($parenthesizedPortion)"
+    return "<br>($parenthesizedPortion)"
 }
 
 

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
@@ -98,7 +98,7 @@ internal class DiagnosticsSupport(private val project: Project) : LspDiagnostics
         val font = EditorUtil.getEditorFont().name
             ?.takeIf { configurations.useEditorFont }
         val tooltip = diagnostic.message
-            .letIf(configurations.addTooltipPrefix) { "Pyright: $it" }
+            .letIf(configurations.addTooltipPrefix) { "<small>Pyright:</small><br>$it" }
         
         val codeSuffix = diagnostic.codeAsString?.toCodeSuffix(font, descriptionHref).orEmpty()
         

--- a/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyrightls/server/diagnostics/DiagnosticsSupport.kt
@@ -42,7 +42,7 @@ private fun String.toPreformattedBlock(font: String?): HtmlChunk.Element {
 
 private fun String.toCodeSuffix(font: String? = null, href: String? = null): String {
     val parenthesizedPortion = href?.let { HtmlChunk.link(it, this).withFont(font) } ?: this
-    return "<br>($parenthesizedPortion)"
+    return " <i>($parenthesizedPortion)</i>"
 }
 
 

--- a/src/main/resources/messages/pyrightls.properties
+++ b/src/main/resources/messages/pyrightls.properties
@@ -13,6 +13,7 @@ configurations.globalExecutable.label = Global executable:
 configurations.useEditorFont.label = Use editor font
 configurations.addTooltipPrefix.label = Prefix with "Pyright:"
 configurations.linkErrorCodes.label = Display error codes as links if possible
+configurations.prettyOutput.label = Display in pretty format
 
 configurations.autoRestartServer.label = Automatically restart server on configuration change
 


### PR DESCRIPTION
I’ve always found the output messages from Pyright to be somewhat hard to read due to the excessive use of quotation marks and indentation. To address this, I’ve modified this plugin to add an option that allows tooltips to be displayed in a format that I find slightly more readable. I’ve attached a screenshot comparing the output formats. I believe the improvement would be even more noticeable with longer messages and deeper indentation.

This is a feature that isn’t even available in VSCode + Pylance, and while I personally find it appealing, I understand that others may have different preferences.

I don’t expect this Pull Request to be merged as is, so feel free to close it. However, I would be delighted if a similar feature were implemented in the future.

#### normal
<img width="943" alt="tooltip_normal" src="https://github.com/user-attachments/assets/931a5e25-aed7-476f-b8c1-522959554100">

#### pretty format
<img width="943" alt="tooltip_pretty" src="https://github.com/user-attachments/assets/ffd25e7c-24d3-462d-925e-ec730294dcc9">


